### PR TITLE
chore: simplify ping endpoint

### DIFF
--- a/api/ping.py
+++ b/api/ping.py
@@ -1,14 +1,7 @@
 from fastapi import FastAPI
-from fastapi.responses import JSONResponse
 
 app = FastAPI()
 
 @app.get("/")
 def ping():
     return {"ok": True, "service": "mangapill"}
-
-# Vercel handler
-def handler(request):
-    from mangum import Mangum
-    asgi_handler = Mangum(app)
-    return asgi_handler(request.scope, request.receive, request.send)


### PR DESCRIPTION
## Summary
- simplify ping endpoint for native Vercel FastAPI

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8fbcca7d8832e9014dc4b72b65953