### PR TITLE
Use async HTTP client for Mangapill scraper

### DIFF
--- a/api/chapter_pages.py
+++ b/api/chapter_pages.py
@@ -5,9 +5,10 @@ from scrapers.mangapill_scraper import MangapillScraper
 app = FastAPI()
 scraper = MangapillScraper()
 
+
 @app.get("/")
-def chapter_pages(url: str) -> List[str]:
+async def chapter_pages(url: str) -> List[str]:
     try:
-        return scraper.get_chapter_pages(url)
+        return await scraper.get_chapter_pages(url)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/api/manga.py
+++ b/api/manga.py
@@ -4,9 +4,10 @@ from scrapers.mangapill_scraper import MangapillScraper
 app = FastAPI()
 scraper = MangapillScraper()
 
+
 @app.get("/")
-def manga(url: str):
+async def manga(url: str):
     try:
-        return scraper.get_manga(url)
+        return await scraper.get_manga(url)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/api/mangapill.py
+++ b/api/mangapill.py
@@ -15,25 +15,30 @@ app.add_middleware(
 
 scraper = MangapillScraper()
 
+
 @app.get("/")  # <— add this
-def root():
+async def root():
     return {"ok": True, "service": "mangapill"}
+
 
 @app.get("/ping")
-def ping():
+async def ping():
     return {"ok": True, "service": "mangapill"}
 
+
 @app.get("/search")
-def search(q: str = Query(..., min_length=1), limit: int = 20):
+async def search(q: str = Query(..., min_length=1), limit: int = 20):
     try:
-        return scraper.search(q, limit)
+        return await scraper.search(q, limit)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @app.get("/manga")
-def manga(url: str):
-    return scraper.get_manga(url)
+async def manga(url: str):
+    return await scraper.get_manga(url)
+
 
 @app.get("/chapter/pages")
-def chapter_pages(url: str) -> List[str]:
-    return scraper.get_chapter_pages(url)
+async def chapter_pages(url: str) -> List[str]:
+    return await scraper.get_chapter_pages(url)

--- a/api/search.py
+++ b/api/search.py
@@ -5,9 +5,10 @@ from scrapers.mangapill_scraper import MangapillScraper
 app = FastAPI()
 scraper = MangapillScraper()
 
+
 @app.get("/")
-def search(q: str = Query(..., min_length=1), limit: int = 20) -> List[Dict]:
+async def search(q: str = Query(..., min_length=1), limit: int = 20) -> List[Dict]:
     try:
-        return scraper.search(q, limit)
+        return await scraper.search(q, limit)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi
 uvicorn[standard]
-requests
+httpx
 beautifulsoup4
 mangum


### PR DESCRIPTION
## Summary
- swap requests for httpx.AsyncClient and make scraper methods async
- update FastAPI endpoints to async def and await scraper
- add httpx to requirements

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8fbd67ef0832eabf01802de03133e